### PR TITLE
Added Static Content Tree View

### DIFF
--- a/python-django.el
+++ b/python-django.el
@@ -437,7 +437,8 @@ Optional argument SHOW-HELP when non-nil causes the help buffer to pop."
       (expand-file-name "manage.py" dir))))
 
 (defvar python-django-info-prefetched-settings
-  '("INSTALLED_APPS" "DATABASES" "MEDIA_ROOT" "STATIC_ROOT" "TEMPLATE_DIRS"))
+  '("INSTALLED_APPS" "DATABASES" "MEDIA_ROOT" "STATIC_ROOT" "TEMPLATE_DIRS"
+    "STATICFILES_DIRS"))
 
 (defvar python-django-info--get-setting-cache nil
   "Alist with cached list of settings.")
@@ -2038,6 +2039,11 @@ The function receives one argument, the status buffer."
     (list
      (cons "MEDIA_ROOT" (python-django-info-get-setting "MEDIA_ROOT"))
      (cons "STATIC_ROOT" (python-django-info-get-setting "STATIC_ROOT"))))
+   (cons
+    "Static Content" (mapcar
+                      (lambda (dir)
+                        (cons dir dir))
+                      (python-django-info-get-setting "STATICFILES_DIRS")))
    (cons
     "Templates" (mapcar
                  (lambda (dir)


### PR DESCRIPTION
Hi,

Thanks for taking the time to create this awesome package for working with Django projects in Emacs. 
I went ahead and added code to list any directory specified under the STATICFILES_DIRS
within a project's settings.py file.

Thanks,
Jonathan
