### PR TITLE
Fix bug where docs >1.9 had wrong url

### DIFF
--- a/python-django.el
+++ b/python-django.el
@@ -2020,7 +2020,9 @@ default to a sane value."
   (browse-url
    (format
     "https://docs.djangoproject.com/en/%s/"
-    (substring (python-django-info-get-version) 0 3))))
+    (mapconcat 'identity
+               (butlast (split-string (python-django-info-get-version) "\\."))
+               "."))))
 
 (defun python-django-cmd-visit-settings ()
   "Visit settings file."


### PR DESCRIPTION
Previous implementation relied on first 3 items of version number `1.9` is ok but `1.10` become `1.1`

New method splits on the `.` and discards the last part before reforming.